### PR TITLE
[fix] pki-authority: Broken script when group contains spaces

### DIFF
--- a/files/secret/pki/lib/pki-authority
+++ b/files/secret/pki/lib/pki-authority
@@ -137,11 +137,11 @@ initialize_environment () {
     config["cert_sign_days"]=""
     config["key_size"]="4096"
 
-    config["public_dir_group"]="$(id -gn)"
-    config["public_file_group"]="$(id -gn)"
+    config["public_dir_group"]="$(id -g)"
+    config["public_file_group"]="$(id -g)"
 
-    config["private_dir_group"]="$(id -gn)"
-    config["private_file_group"]="$(id -gn)"
+    config["private_dir_group"]="$(id -g)"
+    config["private_file_group"]="$(id -g)"
 
     config["public_dir_mode"]="755"
     config["private_dir_mode"]="700"


### PR DESCRIPTION
When $(id -gn) returns a group name with spaces the script fails. 
Without -n the id is used and there are no problems.